### PR TITLE
Adds file to prep for conda forge

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,15 @@
+# Things to always exclude
+global-exclude .git*
+global-exclude .ipynb_checkpoints
+global-exclude *.py[co]
+global-exclude __pycache__/**
+
+# Top-level Config
 include versioneer.py
 include prefect_dask/_version.py
+include LICENSE
+include MANIFEST.in
+include setup.cfg
+include requirements.txt
+include requirements-dev.txt
+


### PR DESCRIPTION
<!-- Thanks for contributing to prefect-dask! 🎉-->

## Summary
<!-- A brief summary explaining the purpose of this PR -->
Was following the steps from https://blog.gishub.org/how-to-publish-a-python-package-on-conda-forge

Upon running:
`conda skeleton pypi prefect-dask`

It encountered:
```
 1146    File "/private/var/folders/tb/fksvh8ms2hl5xnzwrftnx66r0000gq/T/tmpue11za5econda_skeleton_prefect-dask-0.2.0.tar.gz/prefect-dask-0.2.0/setup.py", line 5, in <module>
 1147      with open("requirements.txt") as install_requires_file:
```

Need these files to build the conda skeleton, similar to:
https://github.com/plotly/jupyter-dash/issues/11

After merging, planning to tag a 0.2.0.post.1 release and rerunning the command above

Borrowed mostly from:
https://github.com/PrefectHQ/prefect/blob/main/MANIFEST.in

## Relevant Issue(s)
<!-- If this PR addresses any open issues, please let us know which one here -->
https://github.com/PrefectHQ/prefect-dask/issues/19

## Checklist
- [ ] Summarized PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-dask/blob/main/CHANGELOG.md)
