### PR TITLE
Add back task run key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Make the task names that appear in the Dask dashboard match the Prefect task names - [#31](https://github.com/PrefectHQ/prefect-dask/pull/31)
+
 ### Security
 
 ## 0.2.0

--- a/prefect_dask/task_runners.py
+++ b/prefect_dask/task_runners.py
@@ -215,9 +215,9 @@ class DaskTaskRunner(BaseTaskRunner):
             flow_run = FlowRunContext.get().flow_run
             # Dask displays the text up to the first '-' as the name; the task run key
             # should include the task run name for readability in the dask console.
-            # The flow run count is included for cases where keys will match
-            # if the task run failed and is running again for a retried flow run,
-            # resulting in a retrieval from the Dask cache.
+            # For cases where the task run fails and reruns for a retried flow run,
+            # the flow run count is included so that the keys will not match,
+            # the failed run's key, thus not resulting in a retrieval from the Dask cache.
             dask_key = f"{task_run.name}-{task_run.id.hex}-{flow_run.run_count}"
         else:
             dask_key = key

--- a/prefect_dask/task_runners.py
+++ b/prefect_dask/task_runners.py
@@ -76,6 +76,7 @@ from typing import Awaitable, Callable, Dict, Optional, Union
 from uuid import UUID
 
 import distributed
+from prefect.context import FlowRunContext
 from prefect.futures import PrefectFuture
 from prefect.orion.schemas.states import State
 from prefect.states import exception_to_crashed_state
@@ -211,10 +212,10 @@ class DaskTaskRunner(BaseTaskRunner):
 
         if "task_run" in call_kwargs:
             task_run = call_kwargs["task_run"]
-            dask_key = f"{task_run.name}-r{task_run.run_count}-{task_run.id.hex}"
+            flow_run = FlowRunContext.get().flow_run
+            dask_key = f"{task_run.name}-{task_run.id.hex}-{flow_run.run_count}"
         else:
             dask_key = key
-        print(dask_key)
 
         self._dask_futures[key] = self._client.submit(
             call.func,

--- a/prefect_dask/task_runners.py
+++ b/prefect_dask/task_runners.py
@@ -214,10 +214,10 @@ class DaskTaskRunner(BaseTaskRunner):
             task_run = call_kwargs["task_run"]
             flow_run = FlowRunContext.get().flow_run
             # Dask displays the text up to the first '-' as the name; the task run key
-            # should include the task run name for readability in the dask console.
+            # should include the task run name for readability in the Dask console.
             # For cases where the task run fails and reruns for a retried flow run,
-            # the flow run count is included so that the keys will not match,
-            # the failed run's key, thus not resulting in a retrieval from the Dask cache.
+            # the flow run count is included so that the new key will not match
+            # the failed run's key, therefore not retrieving from the Dask cache.
             dask_key = f"{task_run.name}-{task_run.id.hex}-{flow_run.run_count}"
         else:
             dask_key = key

--- a/prefect_dask/task_runners.py
+++ b/prefect_dask/task_runners.py
@@ -213,14 +213,17 @@ class DaskTaskRunner(BaseTaskRunner):
         if "task_run" in call_kwargs:
             task_run = call_kwargs["task_run"]
             flow_run = FlowRunContext.get().flow_run
+            # Dask displays the text up to the first '-' as the name; the task run key
+            # should include the task run name for readability in the dask console.
+            # The flow run count is included for cases where keys will match
+            # if the task run failed and is running again for a retried flow run,
+            # resulting in a retrieval from the Dask cache.
             dask_key = f"{task_run.name}-{task_run.id.hex}-{flow_run.run_count}"
         else:
             dask_key = key
 
         self._dask_futures[key] = self._client.submit(
             call.func,
-            # Dask displays the text up to the first '-' as the name, the task run key
-            # should include the task run name for readability in the dask console.
             key=dask_key,
             # Dask defaults to treating functions are pure, but we set this here for
             # explicit expectations. If this task run is submitted to Dask twice, the

--- a/prefect_dask/task_runners.py
+++ b/prefect_dask/task_runners.py
@@ -211,9 +211,10 @@ class DaskTaskRunner(BaseTaskRunner):
 
         if "task_run" in call_kwargs:
             task_run = call_kwargs["task_run"]
-            dask_key = f"{task_run.name}-{task_run.id.hex}"
+            dask_key = f"{task_run.name}-r{task_run.run_count}-{task_run.id.hex}"
         else:
             dask_key = key
+        print(dask_key)
 
         self._dask_futures[key] = self._client.submit(
             call.func,

--- a/prefect_dask/task_runners.py
+++ b/prefect_dask/task_runners.py
@@ -208,12 +208,14 @@ class DaskTaskRunner(BaseTaskRunner):
         # unpack the upstream call in order to cast Prefect futures to Dask futures
         # where possible to optimize Dask task scheduling
         call_kwargs = self._optimize_futures(call.keywords)
+        task_run = call_kwargs["task_run"]
+        dask_key = f"{task_run.name}-{task_run.id.hex}"
 
         self._dask_futures[key] = self._client.submit(
             call.func,
             # Dask displays the text up to the first '-' as the name, the task run key
             # should include the task run name for readability in the dask console.
-            key=key,
+            key=dask_key,
             # Dask defaults to treating functions are pure, but we set this here for
             # explicit expectations. If this task run is submitted to Dask twice, the
             # result of the first run should be returned. Subsequent runs would return

--- a/prefect_dask/task_runners.py
+++ b/prefect_dask/task_runners.py
@@ -208,8 +208,12 @@ class DaskTaskRunner(BaseTaskRunner):
         # unpack the upstream call in order to cast Prefect futures to Dask futures
         # where possible to optimize Dask task scheduling
         call_kwargs = self._optimize_futures(call.keywords)
-        task_run = call_kwargs["task_run"]
-        dask_key = f"{task_run.name}-{task_run.id.hex}"
+
+        if "task_run" in call_kwargs:
+            task_run = call_kwargs["task_run"]
+            dask_key = f"{task_run.name}-{task_run.id.hex}"
+        else:
+            dask_key = key
 
         self._dask_futures[key] = self._client.submit(
             call.func,

--- a/tests/test_task_runners.py
+++ b/tests/test_task_runners.py
@@ -152,3 +152,4 @@ class TestDaskTaskRunner(TaskRunnerStandardTestSuite):
         my_flow()
         futures = task_runner._dask_futures.values()
         assert all(future.key.startswith("my_task-") for future in futures)
+        assert all("-r0-" in future.key for future in futures)

--- a/tests/test_task_runners.py
+++ b/tests/test_task_runners.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 import cloudpickle
 import distributed
 import pytest
+from prefect import task, flow
 from prefect.states import State
 from prefect.task_runners import TaskConcurrencyType
 from prefect.testing.fixtures import hosted_orion_api, use_hosted_orion  # noqa: F401
@@ -136,3 +137,18 @@ class TestDaskTaskRunner(TaskRunnerStandardTestSuite):
             assert state is not None, "wait timed out"
             assert isinstance(state, State), "wait should return a state"
             assert state.name == "Crashed"
+
+    def test_dask_task_key_has_prefect_task_name(self):
+        task_runner = DaskTaskRunner()
+
+        @task
+        def my_task():
+            return 1
+        
+        @flow(task_runner=task_runner)
+        def my_flow():
+            my_task.submit()
+
+        my_flow()
+        futures = task_runner._dask_futures.values()
+        assert all(future.key.startswith("my_task-") for future in futures)

--- a/tests/test_task_runners.py
+++ b/tests/test_task_runners.py
@@ -148,8 +148,12 @@ class TestDaskTaskRunner(TaskRunnerStandardTestSuite):
         @flow(task_runner=task_runner)
         def my_flow():
             my_task.submit()
+            my_task.submit()
+            my_task.submit()
 
         my_flow()
         futures = task_runner._dask_futures.values()
+        # ensure task run name is in key
         assert all(future.key.startswith("my_task-") for future in futures)
-        assert all("-r0-" in future.key for future in futures)
+        # ensure flow run retries is in key
+        assert all(future.key.endswith("-1") for future in futures)

--- a/tests/test_task_runners.py
+++ b/tests/test_task_runners.py
@@ -7,7 +7,7 @@ from uuid import uuid4
 import cloudpickle
 import distributed
 import pytest
-from prefect import task, flow
+from prefect import flow, task
 from prefect.states import State
 from prefect.task_runners import TaskConcurrencyType
 from prefect.testing.fixtures import hosted_orion_api, use_hosted_orion  # noqa: F401
@@ -144,7 +144,7 @@ class TestDaskTaskRunner(TaskRunnerStandardTestSuite):
         @task
         def my_task():
             return 1
-        
+
         @flow(task_runner=task_runner)
         def my_flow():
             my_task.submit()


### PR DESCRIPTION
<!-- Thanks for contributing to prefect-dask! 🎉-->

## Summary
<!-- A brief summary explaining the purpose of this PR -->
```python
import time
import distributed
from prefect_dask import DaskTaskRunner
from prefect import flow, task

N = 100

@task()
def f(x):
    time.sleep(1)
    return 2 * x

def main():
    start = time.time()
    tasks = f.map(range(N))
    submitted = time.time()
    return sum([t.result() for t in tasks])

flow(task_runner=DaskTaskRunner())(main)()
```
![image](https://user-images.githubusercontent.com/15331990/191136014-b5beef28-5139-4e5b-9b2a-399d5323609b.png)

## Relevant Issue(s)
<!-- If this PR addresses any open issues, please let us know which one here -->
Closes https://github.com/PrefectHQ/prefect-dask/issues/27

## Checklist
- [ ] Summarized PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-dask/blob/main/CHANGELOG.md)
