### PR TITLE
Fix `DaskTaskRunner` exception handling for Prefect >= 2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `get_dask_client` and `get_async_dask_client` allowing for distributed computation within a task - [#33](https://github.com/PrefectHQ/prefect-dask/pull/33)
-
 ### Changed
 
 ### Deprecated
@@ -19,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Make the task names that appear in the Dask dashboard match the Prefect task names - [#31](https://github.com/PrefectHQ/prefect-dask/pull/31)
+* Updated `DaskTaskRunner` to handle task exceptions correctly in Prefect >= 2.6.0 - [#52](https://github.com/PrefectHQ/prefect-dask/pull/52)
 
 ### Security
 

--- a/prefect_dask/task_runners.py
+++ b/prefect_dask/task_runners.py
@@ -270,7 +270,7 @@ class DaskTaskRunner(BaseTaskRunner):
         except distributed.TimeoutError:
             return None
         except BaseException as exc:
-            return exception_to_crashed_state(exc)
+            return await exception_to_crashed_state(exc)
 
     async def _start(self, exit_stack: AsyncExitStack):
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-prefect>=2.3.0
+prefect>=2.6.0
 distributed==2022.2.0; python_version < '3.8'
 distributed>=2022.5.0; python_version >= '3.8'

--- a/tests/test_task_runners.py
+++ b/tests/test_task_runners.py
@@ -8,6 +8,8 @@ import cloudpickle
 import distributed
 import pytest
 from prefect import flow, task
+from prefect.client.schemas import TaskRun
+from prefect.orion.schemas.states import StateType
 from prefect.states import State
 from prefect.task_runners import TaskConcurrencyType
 from prefect.testing.fixtures import hosted_orion_api, use_hosted_orion  # noqa: F401
@@ -122,21 +124,21 @@ class TestDaskTaskRunner(TaskRunnerStandardTestSuite):
                 f"{task_runner.concurrency_type} task runners."
             )
 
+        task_run = TaskRun(flow_run_id=uuid4(), task_key="foo", dynamic_key="bar")
+
         async def fake_orchestrate_task_run():
             raise exception
 
-        test_key = uuid4()
-
         async with task_runner.start():
             await task_runner.submit(
+                key=task_run.id,
                 call=partial(fake_orchestrate_task_run),
-                key=test_key,
             )
 
-            state = await task_runner.wait(test_key, 5)
+            state = await task_runner.wait(task_run.id, 5)
             assert state is not None, "wait timed out"
             assert isinstance(state, State), "wait should return a state"
-            assert state.name == "Crashed"
+            assert state.type == StateType.CRASHED
 
     def test_dask_task_key_has_prefect_task_name(self):
         task_runner = DaskTaskRunner()

--- a/tests/test_task_runners.py
+++ b/tests/test_task_runners.py
@@ -10,7 +10,7 @@ import cloudpickle
 import distributed
 import prefect.engine
 import pytest
-from distributed import KilledWorker
+from distributed.scheduler import KilledWorker
 from prefect import flow, get_run_logger, task
 from prefect.client.schemas import TaskRun
 from prefect.orion.schemas.states import StateType

--- a/tests/test_task_runners.py
+++ b/tests/test_task_runners.py
@@ -146,8 +146,8 @@ class TestDaskTaskRunner(TaskRunnerStandardTestSuite):
     @pytest.mark.parametrize(
         "exceptions",
         [
-            (KeyboardInterrupt(), KilledWorker("", None, 0)),
-            (ValueError("test"), ValueError("test")),
+            (KeyboardInterrupt(), KilledWorker),
+            (ValueError("test"), ValueError),
         ],
     )
     async def test_exception_to_crashed_state_in_flow_run(
@@ -159,7 +159,7 @@ class TestDaskTaskRunner(TaskRunnerStandardTestSuite):
                 f"{task_runner.concurrency_type} task runners."
             )
 
-        (raised_exception, state_exception) = exceptions
+        (raised_exception, state_exception_type) = exceptions
 
         def throws_exception_before_task_begins(
             task, task_run, parameters, wait_for, result_factory, settings
@@ -186,11 +186,11 @@ class TestDaskTaskRunner(TaskRunnerStandardTestSuite):
 
         # ensure that the type of exception raised by the flow matches the type of
         # exception we expected the task runner to receive.
-        with pytest.raises(type(state_exception)) as exc:
+        with pytest.raises(state_exception_type) as exc:
             await test_flow()
             # If Dask passes the same exception type back, it should pass
             # the equality check
-            if type(raised_exception) == type(state_exception):
+            if type(raised_exception) == state_exception_type:
                 assert exceptions_equal(raised_exception, exc)
 
     def test_dask_task_key_has_prefect_task_name(self):

--- a/tests/test_task_runners.py
+++ b/tests/test_task_runners.py
@@ -133,7 +133,7 @@ class TestDaskTaskRunner(TaskRunnerStandardTestSuite):
                 key=test_key,
             )
 
-            state = await (await task_runner.wait(test_key, 5))
+            state = await task_runner.wait(test_key, 5)
             assert state is not None, "wait timed out"
             assert isinstance(state, State), "wait should return a state"
             assert state.name == "Crashed"


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to prefect-dask 🎉!

We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Run `pre-commit install && pre-commit run --all` for linting.

Happy engineering!
-->

<!-- Include an overview here -->
In Prefect 2.6.0, `exception_to_crashed_state` changed from a sync function to an async function that needs to be awaited. `DaskTaskRunner` does not currently await this call, resulting in users seeing `coroutine' object has no attribute 'type'` when an unhandled exception occurs while a Dask worker node is trying to unpickle and load the task. 

Consequently, it is difficult to see and understand what went wrong. Looking at logs from the Dask worker node(s) that tried to execute the failed task(s) will show what went wrong, but not all users who can submit work to a Dask cluster will have access to individual worker node logs. 

This PR updates `DaskTaskRunner` to resolve the issue, updates an existing unit test, and adds another unit test to prevent regression.

<!-- Link to issue -->
Closes #53 

In its present form, the changes in the PR will make future releases of `prefect-dask` require Prefect >= 2.6.0 instead of the current requirement of >= 2.3.0. We should be able to keep `prefect-dask` backwards compatible with older Prefect releases with a bit of extra work; I can update this PR to do so if necessary.

### Example
* Create a Dask cluster with worker nodes running in a Python environment that is missing a dependency required to run a Prefect task. 
* A quick way to do this is by using `dask-kubernetes` to spin up a cluster where the workers do not have the `prefect` package installed. Put the following in a Python file and run it to start a suitable cluster:
```python
from dask_kubernetes.operator import KubeCluster
cluster = KubeCluster(
    name="prefect-dask",
    image='ghcr.io/dask/dask:latest',
)
cluster.scale(2)
```
* Once the cluster is running, use `kubectl` to forward port 8786 to the K8s dask cluster: `kubectl port-forward service/prefect-dask-scheduler 8786:8786`
* Put the following in a Python file and run it:
```python
from prefect import task, flow
from prefect_dask import DaskTaskRunner

@task
def extract() -> list:
    return [1, 2, 3, 4, 5, 6]

@task(retries=3, retry_delay_seconds=15)
def transform(number: int) -> int:
    return number * 2

@task()
def load(numbers: list) -> list:
    return [i for i in numbers if i]

@flow(
    name="Dask Kubernetes Flow",
    task_runner=DaskTaskRunner(address="127.0.0.1:8786"),
)

def main():
    numbers = extract()
    tranformed_numbers = transform.map(numbers)
    numbers_twice = transform.map(tranformed_numbers)
    result = load(numbers=numbers_twice)

if __name__ == "__main__":
    main()
```
* Observe that the flow run crashes with `AttributeError: 'coroutine' object has no attribute 'type'`
### Steps to QA
* Pull in this PR's updated code. 
* Re-run the flow above and observe that task run failures now shows the actual cause of the task run failure: `Crash detected! Execution was interrupted by an unexpected exception: ModuleNotFoundError: No module named 'prefect'`. 


<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "Closes #<ISSUE_NUMBER>"
- [x] This pull request includes tests or only affects documentation. **Updates existing test to use the task runner's `wait` method the same way Prefect uses It during task execution**
- [x] Summarized PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-dask/blob/main/CHANGELOG.md)
