### PR TITLE
Await the adapt call of a dask cluster instance if it's an asynchronous method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,6 @@ dmypy.json
 
 # Jupyter notebook
 *.ipynb
+
+# Jetbrains
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Updated `DaskTaskRunner` to await the `adapt` method call of a dask cluster instance if it's an asynchronous method - [#77](https://github.com/PrefectHQ/prefect-dask/pull/77)
+
 ### Security
 
 ## 0.2.2

--- a/prefect_dask/task_runners.py
+++ b/prefect_dask/task_runners.py
@@ -71,6 +71,7 @@ Example:
     ```
 """
 
+import inspect
 from contextlib import AsyncExitStack
 from typing import Awaitable, Callable, Dict, Optional, Union
 from uuid import UUID
@@ -296,7 +297,9 @@ class DaskTaskRunner(BaseTaskRunner):
                 self.cluster_class(asynchronous=True, **self.cluster_kwargs)
             )
             if self.adapt_kwargs:
-                self._cluster.adapt(**self.adapt_kwargs)
+                adapt_response = self._cluster.adapt(**self.adapt_kwargs)
+                if inspect.isawaitable(adapt_response):
+                    await adapt_response
 
         self._client = await exit_stack.enter_async_context(
             distributed.Client(


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->
This PR will await the `adapt` call when the underlying dask cluster implementation returns a future for that method.

As discussed in the [issue](https://github.com/PrefectHQ/prefect-dask/issues/57), it seemed like an update that should be done upstream in the `dask-kubernetes` package but [according to its maintainer](https://github.com/dask/dask-kubernetes/issues/645#issuecomment-1403426252), the new `operator.KubeCluster` is doing I/O during adapt so it should in theory be awaited when run asynchronously.

Closes #57 

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-dask/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-dask/blob/main/CHANGELOG.md)
