### PR TITLE
Avoid retrying completed tasks on failing workers

### DIFF
--- a/prefect_dask/task_runners.py
+++ b/prefect_dask/task_runners.py
@@ -316,8 +316,6 @@ class DaskTaskRunner(BaseTaskRunner):
         try:
             async for _, res in future:
                 return res
-        except distributed.TimeoutError:
-            return None
         except BaseException as exc:
             return await exception_to_crashed_state(exc)
 


### PR DESCRIPTION
This PR is an attempt to solve the completed tasks from failing worker retry behavior we experience with Dask.
More info in the [related issue](https://github.com/PrefectHQ/prefect-dask/issues/101).

Closes #101 

I didn't add any tests yet since it could be great to have the maintainer's opinion on how to solve this problem differently first.

Please note that it is not possible yet to support a timeout during result fetching with the `as_completed` class so that's a regression to consider with the usage of this class. There is an [old draft PR](https://github.com/dask/distributed/pull/3133) on the `dask/distributed` repo to support this but it seems stalled. Also, even with the timeout support on the `as_completed` class, I don't see any good way to provide the timeout when the `wait` method is called.

### Example

When rerunning the MCVE from the linked issue, the completed tasks from the `worker 2` are not retried on the `worker 1`.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-dask/issues/new/choose) first.
- [ ] Includes tests or only affects documentation.
- [ ] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [ ] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-dask/blob/main/CHANGELOG.md)
