### PR TITLE
'Update the pin on `prefect` version'

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"

--- a/prefect_dask/task_runners.py
+++ b/prefect_dask/task_runners.py
@@ -274,7 +274,7 @@ class DaskTaskRunner(BaseTaskRunner):
             # the failed run's key, therefore not retrieving from the Dask cache.
             dask_key = f"{task_run.name}-{task_run.id.hex}-{flow_run.run_count}"
         else:
-            dask_key = key
+            dask_key = str(key)
 
         self._dask_futures[key] = self._client.submit(
             call.func,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-prefect >=2.13.5
+prefect>=2.13.5
 distributed==2022.2.0; python_version < '3.8'
 distributed>=2022.5.0,!=2023.3.2,!=2023.3.2.1,!=2023.4.*,!=2023.5.*; python_version >= '3.8' # don't allow versions from 2023.3.2 to 2023.5 (inclusive) due to issue with get_client starting in 2023.3.2 (fixed in 2023.6.0) - https://github.com/dask/distributed/issues/7763

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-prefect>=2.8.2
+prefect >=2.13.5
 distributed==2022.2.0; python_version < '3.8'
 distributed>=2022.5.0,!=2023.3.2,!=2023.3.2.1,!=2023.4.*,!=2023.5.*; python_version >= '3.8' # don't allow versions from 2023.3.2 to 2023.5 (inclusive) due to issue with get_client starting in 2023.3.2 (fixed in 2023.6.0) - https://github.com/dask/distributed/issues/7763

--- a/tests/test_task_runners.py
+++ b/tests/test_task_runners.py
@@ -114,6 +114,16 @@ class TestDaskTaskRunner(TaskRunnerStandardTestSuite):
             request.param._pytestfixturefunction.name or request.param.__name__
         )
 
+
+    def test_sync_task_timeout(self, task_runner):
+        """
+        This test is inherited from the prefect testing module and it may not appropriately 
+        skip on Windows. Here we skip it explicitly.
+        """
+        if sys.platform.startswith("win"):
+            pytest.skip("cancellation due to timeouts is not supported on Windows")
+        super().test_async_task_timeout(task_runner)
+
     async def test_is_pickleable_after_start(self, task_runner):
         """
         The task_runner must be picklable as it is attached to `PrefectFuture` objects

--- a/tests/test_task_runners.py
+++ b/tests/test_task_runners.py
@@ -114,11 +114,10 @@ class TestDaskTaskRunner(TaskRunnerStandardTestSuite):
             request.param._pytestfixturefunction.name or request.param.__name__
         )
 
-
     def test_sync_task_timeout(self, task_runner):
         """
-        This test is inherited from the prefect testing module and it may not appropriately 
-        skip on Windows. Here we skip it explicitly.
+        This test is inherited from the prefect testing module and it may not
+        appropriately skip on Windows. Here we skip it explicitly.
         """
         if sys.platform.startswith("win"):
             pytest.skip("cancellation due to timeouts is not supported on Windows")


### PR DESCRIPTION
As part of our work adding support for Pydantic 2, we removed its pin in 
`prefect`'s `requirements.txt`. This means that it's possible to have 
`prefect`, `pydantic>=2`, and any version of this collection installed. But, 
the collection(s) only support `pydantic>=2` in their latest versions. This 
PR adds a pin on the collection's `requirements.txt` to make sure that it is 
only installed with the correct version `prefect` that supports `pydantic>=2`