### PR TITLE
Bumps build's python version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - name: Install packages
         run: |


### PR DESCRIPTION
We've stopped publishing `prefect` for python3.7. Since the current pin 
on `prefect` depends on recent versions, we have to build using python3.8